### PR TITLE
Changes from background agent bc-58c885cd-c3e0-4eeb-a7e3-fce095269b3b

### DIFF
--- a/backend/routes.js
+++ b/backend/routes.js
@@ -5483,7 +5483,7 @@ router.post('/bulk-upload/:module', authenticateToken, authorizeRole('administra
           if (module === 'network_routes') {
             console.log(`[BULK UPLOAD] Processing row ${index + 1} for network_routes:`, JSON.stringify(row, null, 2));
             console.log(`[BULK UPLOAD] Expected fields:`, config.templateFields);
-            sql = `INSERT INTO network_routes (${config.templateFields.join(', ')}) VALUES (${config.templateFields.map(() => '?').join(', ')})`;
+            sql = `INSERT OR REPLACE INTO network_routes (${config.templateFields.join(', ')}) VALUES (${config.templateFields.map(() => '?').join(', ')})`;
             values = config.templateFields.map(field => row[field] || null);
             console.log(`[BULK UPLOAD] Generated SQL:`, sql);
             console.log(`[BULK UPLOAD] Values for row ${index + 1}:`, values);


### PR DESCRIPTION
Update `network_routes` bulk upload to use `INSERT OR REPLACE` to handle duplicate `circuit_id` entries.

The previous `INSERT` statement would fail on any duplicate `circuit_id`, causing the entire bulk upload transaction to roll back. This change allows existing records to be updated, ensuring the bulk upload completes successfully without errors for duplicate entries.

---

[Open in Web](https://cursor.com/agents?id=bc-58c885cd-c3e0-4eeb-a7e3-fce095269b3b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-58c885cd-c3e0-4eeb-a7e3-fce095269b3b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)