### PR TITLE
Fix outbound api self-signed certificate errors

### DIFF
--- a/backend/liveLatencyService.js
+++ b/backend/liveLatencyService.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const https = require('https');
 const db = require('./db');
 const { encrypt, decrypt } = require('./encryption');
 const { logUserActivity } = require('./auth');
@@ -162,7 +163,8 @@ class LiveLatencyService {
       timeout: this.defaultTimeout,
       headers: {
         'accept': '*/*'
-      }
+      },
+      httpsAgent: new https.Agent({ rejectUnauthorized: false })
     });
 
     // Add authentication


### PR DESCRIPTION
Temporarily disable TLS certificate verification in `LiveLatencyService.createApiClient` to allow outbound API calls to self-signed endpoints.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a33d11a-8b2f-4b3a-a3cb-c3fada7ec6fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a33d11a-8b2f-4b3a-a3cb-c3fada7ec6fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

