### PR TITLE
Fix live latency api encryption error

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -9,11 +9,13 @@ module.exports = {
       env: {
         NODE_ENV: 'production',
         PORT: 4000,
-        JWT_SECRET: 'your-super-secure-jwt-secret-change-this-in-production'
+        JWT_SECRET: 'your-super-secure-jwt-secret-change-this-in-production',
+        ENCRYPTION_KEY: '7b864e1b14288ca6c9c7b905242bd048e5f468c2d008a6a5fe8d940ab7bf40b3'
       },
       env_production: {
         NODE_ENV: 'production',
-        PORT: 4000
+        PORT: 4000,
+        ENCRYPTION_KEY: '7b864e1b14288ca6c9c7b905242bd048e5f468c2d008a6a5fe8d940ab7bf40b3'
       },
       max_memory_restart: '1G',
       min_uptime: '10s',

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -10,12 +10,12 @@ module.exports = {
         NODE_ENV: 'production',
         PORT: 4000,
         JWT_SECRET: 'your-super-secure-jwt-secret-change-this-in-production',
-        ENCRYPTION_KEY: '7b864e1b14288ca6c9c7b905242bd048e5f468c2d008a6a5fe8d940ab7bf40b3'
+        ENCRYPTION_KEY: '40d1aaf98664fa7f23d6f3bf8fbb9c7af3e534f9eb8c5e35a108f4d1da7281fe'
       },
       env_production: {
         NODE_ENV: 'production',
         PORT: 4000,
-        ENCRYPTION_KEY: '7b864e1b14288ca6c9c7b905242bd048e5f468c2d008a6a5fe8d940ab7bf40b3'
+        ENCRYPTION_KEY: '40d1aaf98664fa7f23d6f3bf8fbb9c7af3e534f9eb8c5e35a108f4d1da7281fe'
       },
       max_memory_restart: '1G',
       min_uptime: '10s',


### PR DESCRIPTION
Add `ENCRYPTION_KEY` to PM2 configuration to resolve password encryption failure in production for the live latency API.

The live latency API was failing to update passwords due to a missing `ENCRYPTION_KEY` environment variable, which is required for encryption in production mode. This PR adds the necessary key to the PM2 ecosystem configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a13b90d-35fe-40aa-b2d4-0e84244e2860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a13b90d-35fe-40aa-b2d4-0e84244e2860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

